### PR TITLE
Tar fastqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM ubuntu:jammy
 # libbz2-dev:      install samtools/htslib/bcftools
 # liblzma-dev:     use cram files
 # libncurses5-dev: use samtools tview
+# libssl-dev:      install python with pip
 # make:            install samtools/htslib/bcftools
 # sudo:            wrangle some installations (might not be 100% necessary)
 # wget:            install most stuff
@@ -24,22 +25,28 @@ apt-get install -y lbzip2 && \
 apt-get install -y libbz2-dev && \
 apt-get install -y liblzma-dev && \
 apt-get install -y libncurses5-dev && \
+apt-get install -y libssl-dev && \
 apt-get install -y make && \
 apt-get install -y sudo && \
 apt-get install -y wget && \
 apt-get install -y zlib1g-dev && \
 apt-get clean
 
-# soft prereqs: cpan, curl, fd-find, pigz, python, tree, vim
+# soft prereqs: cpan, curl, fd-find, pigz, tree, vim
 RUN apt-get update && \
 apt-get install -y cpanminus && \
 apt-get install -y curl && \
 apt-get install -y fd-find && \
 apt-get install -y pigz && \
-apt-get install -y python3.10 && \
 apt-get install -y tree && \
 apt-get install -y vim && \
 apt-get clean
+
+# python and friends
+RUN wget https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tgz && tar -xf Python-3.11.1.tgz && cd Python-3.11.1 && ./configure --disable-test-modules --enable-optimizations && make && sudo make install 
+RUN pip3 install numpy
+RUN pip3 install pandas
+RUN pip3 install Matplotlib
 
 # install entrez direct
 RUN sh -c "$(wget -q ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/install-edirect.sh -O -)"
@@ -60,10 +67,8 @@ RUN cd bin && wget https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/3.0.1/sratoolkit.3
 
 # set path variable and some aliases
 RUN echo 'alias fdfind="fd"' >> ~/.bashrc
-RUN echo 'alias python="python3.10"' >> ~/.bashrc
-RUN echo 'alias python3="python3.10"' >> ~/.bashrc
-RUN echo 'alias pydoc3="ydoc3.10"' >> ~/.bashrc
-RUN echo 'alias pygettext3="pygettext3.10"' >> ~/.bashrc
+RUN echo 'alias python="python3"' >> ~/.bashrc
+RUN echo 'alias pip="pip3"' >> ~/.bashrc
 ENV PATH=/bin:/root/edirect/:/bin/sratoolkit.3.0.1-ubuntu64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # attempt configure vdb
@@ -71,4 +76,4 @@ ENV PATH=/bin:/root/edirect/:/bin/sratoolkit.3.0.1-ubuntu64/bin:/usr/local/sbin:
 RUN x | vdb-config --interactive || :
 
 # cleanup
-RUN sudo rm /bin/bcftools-1.16.tar.bz2 && sudo rm /bin/samtools-1.16.1.tar.bz2 && sudo rm /bin/sratoolkit.3.0.1-ubuntu64.tar.gz
+RUN sudo rm /bin/bcftools-1.16.tar.bz2 && sudo rm /bin/samtools-1.16.1.tar.bz2 && sudo rm /bin/sratoolkit.3.0.1-ubuntu64.tar.gz && sudo rm Python-3.11.1.tgz && sudo rm -rf Python-3.11.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# SRAnwrp [![DockerHub Link](https://img.shields.io/docker/v/ashedpotatoes/sranwrp/1.0.8?logo=docker)](https://hub.docker.com/r/ashedpotatoes/sranwrp/tags) [![Quay.io Link](https://img.shields.io/badge/quay.io-1.0.8-blue?logo=redhat "Docker Repository on Quay")](https://quay.io/repository/aofarrel/sranwrp)
-SRAnwrp ("Saran Wrap") envelops several SRA-related tools in the warm, polyethylene embrace of a single Docker image. For the sake of simplicity, releases on main follow the same versioning scheme as the Docker image.
+# SRAnwrp [![DockerHub Link](https://img.shields.io/docker/v/ashedpotatoes/sranwrp/1.1.0?logo=docker)](https://hub.docker.com/r/ashedpotatoes/sranwrp/tags) [![Quay.io Link](https://img.shields.io/badge/quay.io-1.1.0-blue?logo=redhat "Docker Repository on Quay")](https://quay.io/repository/aofarrel/sranwrp)
+SRAnwrp ("Saran Wrap") envelops several SRA-related tools in the warm, polyethylene embrace of a single Ubuntu-based Docker image. For the sake of simplicity, releases on main follow the same versioning scheme as the Docker image.
 
 ## What tasks can it perform?
 The combination of e-direct and sra-tools allows it do basically anything you can do from SRA's website. These exist in the form of WDL workflows -- [more on WDL here](./wdl.md).
@@ -20,22 +20,26 @@ Here's [some other tasks](./tasks/processing_tasks.wdl) that can help you conver
 
 ## What's included in the Docker image?
 Non-exhaustive list:
-* bedtools-latest
+* bash-5.1.16(1)-release
+* [bedtools-latest](https://github.com/arq5x/bedtools2)
 * bcftools-1.16
 * cpan-latest
 * curl-latest
-* entrez-direct-latest (aka edirect)
+* [entrez-direct-latest](https://www.ncbi.nlm.nih.gov/books/NBK179288/) (aka edirect)
 * gcc-latest
 * htslib-1.16
 * make-latest
+* Matplotlib-latest
+* [numpy-latest](https://github.com/numpy/numpy)
+* [pandas-latest](https://github.com/pandas-dev/pandas)
 * [pigz-latest](https://github.com/madler/pigz)
-* python-3.10
-	* aliased to python and python3
-	* **note:** when running non-interactively, the aliases will not be read. you must call Python invoking `python3.10`
+* python-3.11
+	* **note:** must be called with `python3` instead of `python` (and `pip3` instead of `pip`) when running non-interactively
 * [samtools-1.16](https://github.com/samtools/samtools) 
+  * mpileup, minimap2, fixmate, etc
 * [sra-tools-3.0.1](https://github.com/ncbi/sra-tools) (aka SRAtools, SRA tools, SRA toolkit, etc)
 	* align-info, fastq-dump, fasterq-dump, prefetch, sam-dump, sra-pileup, etc
-	* Note that [ncbi/ncbi-vdb](https://github.com/ncbi/ncbi-vdb) was merged with sra-tools in sra-tools-3.0.0 and vdb-get was retired in 3.0.1
+	* fyi: [ncbi/ncbi-vdb](https://github.com/ncbi/ncbi-vdb) was merged with sra-tools in sra-tools-3.0.0 and vdb-get was retired in 3.0.1
 * sudo-latest
 * tree-latest
 * vim-latest

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -126,7 +126,6 @@ task pull_fq_from_biosample {
 					else
 						# don't fail, but give no output
 						rm *.fastq
-						exit 0
 					fi
 				else
 					if [ `expr $NUMBER_OF_FQ` != 3 ]
@@ -140,7 +139,6 @@ task pull_fq_from_biosample {
 						else
 							# could probably adapt the 3-case
 							rm *.fastq
-							exit 0
 						fi
 
 					fi
@@ -178,13 +176,13 @@ task pull_fq_from_biosample {
 		if [ ~{tar_outputs} == "true" ]
 		then
 			# double check that there actually are fastqs
+			echo "Tarring outputs (if they exist)"
 			NUMBER_OF_FQ=$(ls *.fastq | grep -v / | wc -l)
-			if [ `expr $NUMBER_OF_FQ` == 0 ]
+			if [ ! `expr $NUMBER_OF_FQ` == 0 ]
 			then
 				tar -tf ~{biosample_accession}.tar --wildcards '*.fastq'
 			fi
 		fi
-		
 
 	>>>
 

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -181,7 +181,7 @@ task pull_fq_from_biosample {
 			if [ ! `expr $NUMBER_OF_FQ` == 0 ]
 			then
 				FQ=$(ls *.fastq)
-				tar -rf  SRS1528302.tar $FQ
+				tar -rf ~{biosample_accession}.tar $FQ
 			fi
 		fi
 

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -86,6 +86,7 @@ task pull_fq_from_biosample {
 	input {
 		String biosample_accession
 
+		Boolean tar_outputs = false
 		Boolean fail_on_invalid = false
 		Int disk_size = 50
 		Int preempt = 1
@@ -173,6 +174,13 @@ task pull_fq_from_biosample {
 			mv -- "$fq" "~{biosample_accession}_${fq%.fastq}.fastq"
 		done
 
+		# 4. tar the outputs, if that's what you want
+		if [ ~{tar_outputs} == "true" ]
+		then
+			tar -tf ~{biosample_accession}.tar --wildcards '*.fastq'
+		fi
+		
+
 	>>>
 
 	runtime {
@@ -185,6 +193,7 @@ task pull_fq_from_biosample {
 
 	output {
 		Array[File?] fastqs = glob("*.fastq")
+		File? tarball_fastqs = glob("*.tar")[0]
 	}
 }
 

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -179,9 +179,10 @@ task pull_fq_from_biosample {
 		then
 			# double check that there actually are fastqs
 			NUMBER_OF_FQ=$(ls *.fastq | grep -v / | wc -l)
-			f [ `expr $NUMBER_OF_FQ` == 0 ]
+			if [ `expr $NUMBER_OF_FQ` == 0 ]
 			then
 				tar -tf ~{biosample_accession}.tar --wildcards '*.fastq'
+			fi
 		fi
 		
 

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -180,7 +180,8 @@ task pull_fq_from_biosample {
 			NUMBER_OF_FQ=$(ls *.fastq | grep -v / | wc -l)
 			if [ ! `expr $NUMBER_OF_FQ` == 0 ]
 			then
-				tar -tf ~{biosample_accession}.tar --wildcards '*.fastq'
+				FQ=$(ls *.fastq)
+				tar -rf  SRS1528302.tar $FQ
 			fi
 		fi
 

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -177,7 +177,11 @@ task pull_fq_from_biosample {
 		# 4. tar the outputs, if that's what you want
 		if [ ~{tar_outputs} == "true" ]
 		then
-			tar -tf ~{biosample_accession}.tar --wildcards '*.fastq'
+			# double check that there actually are fastqs
+			NUMBER_OF_FQ=$(ls *.fastq | grep -v / | wc -l)
+			f [ `expr $NUMBER_OF_FQ` == 0 ]
+			then
+				tar -tf ~{biosample_accession}.tar --wildcards '*.fastq'
 		fi
 		
 


### PR DESCRIPTION
# Docker changes
* Switch from Python 3.10 to 3.11
* Include numpy, pandas, and matplotlib
* Python now evoked non-interactively via `python3` instead of needing to specify the specific version
* No longer apt-get install Python, now we compile it the hard way
* Include libssl-dev, which should mean pip now exists/works

# WDL changes
You can now tar the fastqs that you pull, which can make certain types of scattering easier to work with.

Related: https://github.com/aofarrel/clockwork-wdl/pull/16
