### PR TITLE
Filter out NA accessions

### DIFF
--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -30,7 +30,7 @@ task extract_accessions_from_file {
 	for line in (f.readlines()):
 		if line == "":
 			pass
-		elif line == "NA" && "~{filter_na}" == "true":
+		elif line == "NA" and "~{filter_na}" == "true":
 			print("WARNING -- NA found")
 			pass
 		else:

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -17,6 +17,7 @@ task extract_accessions_from_file {
 		# uses NCBI's "default order." Either works.
 		File accessions_file
 		Int? preempt = 1
+		Boolean? filter_na = true
 	}
 	Int disk_size = ceil(size(accessions_file, "GB")) * 2
 
@@ -28,6 +29,9 @@ task extract_accessions_from_file {
 	valid = []
 	for line in (f.readlines()):
 		if line == "":
+			pass
+		elif line == "NA" && "~{filter_na}" == "true":
+			print("WARNING -- NA found")
 			pass
 		else:
 			split = line.split("\t")


### PR DESCRIPTION
It turns out lineage 3 had an NA hiding on line 640! Because it didn't result in a valid pull, it just showed up as NA with no second line after the cat task.

Since the output of the pull task is optional, this is probably not a big deal. But let's fix it anyway.