### PR TITLE
Keep track of diff names, add bc to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN pip3 install numpy
 RUN pip3 install pandas
 RUN pip3 install Matplotlib
 RUN pip3 install firecloud
+RUN pip3 install taxoniumtools
 
 # install entrez direct
 RUN sh -c "$(wget -q ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/install-edirect.sh -O -)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:jammy
 # hard prereqs
 # autoconf:        install samtools/htslib/bcftools
 # gcc:             install samtools/htslib/bcftools
+# git:             install seqtk
 # lbzip2:          install samtools/htslib/bcftools
 # libbz2-dev:      install samtools/htslib/bcftools
 # libffi-dev:      fix some pip installs failing due to lack of '_ctypes' module
@@ -22,6 +23,7 @@ FROM ubuntu:jammy
 
 RUN apt-get update && \
 apt-get install -y autoconf && \
+apt-get install -y git && \
 apt-get install -y gcc && \
 apt-get install -y lbzip2 && \
 apt-get install -y libbz2-dev && \
@@ -35,8 +37,9 @@ apt-get install -y wget && \
 apt-get install -y zlib1g-dev && \
 apt-get clean
 
-# good to have: cpan, curl, fd-find, pigz, tree, vim
+# good to have: bc, cpan, curl, fd-find, pigz, tree, vim
 RUN apt-get update && \
+apt-get install -y bc && \
 apt-get install -y cpanminus && \
 apt-get install -y curl && \
 apt-get install -y fd-find && \
@@ -63,7 +66,6 @@ RUN cd bin && wget https://github.com/samtools/samtools/releases/download/1.16.1
 RUN cd bin && wget https://github.com/samtools/bcftools/releases/download/1.16/bcftools-1.16.tar.bz2 && tar -xf bcftools-1.16.tar.bz2 && cd bcftools-1.16 && ./configure && make && make install
 
 # install seqtk
-RUN apt-get install -y git
 RUN git clone https://github.com/lh3/seqtk.git && cd seqtk && make && cd .. && mv seqtk bin/seqtk
 
 # grab premade sra-tool binaries

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -105,7 +105,8 @@ task cat_files {
 		for FILE in "${FILES[@]}"
 		do
 			# check if it's in the removal guide and below threshold
-			this_files_info=$(awk -v file_to_check="$FILE" '$1 == file_to_check' removal_guide.tsv)
+			basename_file=$(basename "$FILE")
+			this_files_info=$(awk -v file_to_check="$basename_file" '$1 == file_to_check' removal_guide.tsv)
 			echo "$this_files_info"
 			echo "$this_files_info" > temp
 			if [[ ! "$this_files_info" = "" ]]

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -44,7 +44,7 @@ task extract_accessions_from_file {
 	runtime {
 		cpu: 4
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/sranwrp:1.1.0"
+		docker: "ashedpotatoes/sranwrp:1.1.6"
 		memory: "8 GB"
 		preemptible: preempt
 	}
@@ -113,7 +113,8 @@ task cat_files {
 			then
 				# okay, we have information about this file. is it above the removal threshold?
 				this_files_value=$(cut -f2 temp)
-				if [[ $this_files_value -gt ~{removal_threshold} ]]
+				is_bigger=$(echo "$this_files_value>~{removal_threshold}" | bc)
+				if [[ $is_bigger == 0 ]]
 				then
 					cat "$FILE" >> "~{out_filename}"
 
@@ -155,7 +156,7 @@ task cat_files {
 	runtime {
 		cpu: 4
 		disks: "local-disk " + disk_size + " SSD"
-		docker: "ashedpotatoes/sranwrp:1.0.8"
+		docker: "ashedpotatoes/sranwrp:1.1.6"
 		memory: "8 GB"
 		preemptible: preempt
 	}

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -56,9 +56,14 @@ task extract_accessions_from_file {
 
 task cat_files {
 	# Concatenate Array[File] into a single File.
+	#
+	# If removal_candidates is defined, those files will be cat
+	# first to create a TSV containing
 
 	input {
 		Array[File] files
+		Array[File]? removal_candidates
+		Int? removal_thresholds
 		String out_filename = "all.txt"
 		Int preempt = 1
 		Boolean keep_only_unique_lines = false
@@ -88,12 +93,7 @@ task cat_files {
 		then
 			for FILE in "${FILES[@]}"
 			do
-				echo "checking file $FILE"
 				firstline=$(head -1 "$FILE")
-				echo "first line is ${firstline}"
-				echo "0th is ${firstline:0}"
-				echo "1st is ${firstline:1}"
-				echo "2nd is ${firstline:2}"
 				echo "${firstline:1}" >> firstlines.txt
 			done
 		else

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -100,6 +100,7 @@ task cat_files {
 
 	if [[ ! "~{sep=' ' removal_candidates}" = "" ]]
 	then
+		echo "Checking which files ought to not be included..."
 		cat ~{sep=" " removal_candidates} >> removal_guide.tsv
 		FILES=(~{sep=" " files})
 		for FILE in "${FILES[@]}"
@@ -107,7 +108,6 @@ task cat_files {
 			# check if it's in the removal guide and below threshold
 			basename_file=$(basename "$FILE")
 			this_files_info=$(awk -v file_to_check="$basename_file" '$1 == file_to_check' removal_guide.tsv)
-			echo "$this_files_info"
 			echo "$this_files_info" > temp
 			if [[ ! "$this_files_info" = "" ]]
 			then
@@ -133,16 +133,15 @@ task cat_files {
 				
 				else
 					# this is below the theshold
-					echo "$FILE's value of $this_files_value is below threshold. It won't be included."
+					echo "$basename_file's value of $this_files_value is below threshold. It won't be included."
 				fi
 			else
-				echo "WARNING: Removal guide exists but can't find $FILE in it! Skipping..."
+				echo "WARNING: Removal guide exists but can't find $basename_file in it! Skipping..."
 			fi
 		done
 	fi
 
 	touch "~{out_filename}"
-	cat ~{sep=" " files} >> "~{out_filename}"
 
 	if [[ "~{keep_only_unique_lines}" = "true" ]]
 	then

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -88,9 +88,13 @@ task cat_files {
 		then
 			for FILE in "${FILES[@]}"
 			do
-				echo "${firstline}"
+				echo "checking file $FILE"
 				firstline=$(head -1 "$FILE")
-				echo "${firstline:0}" >> firstlines.txt
+				echo "first line is ${firstline}"
+				echo "0th is ${firstline:0}"
+				echo "1st is ${firstline:1}"
+				echo "2nd is ${firstline:2}"
+				echo "${firstline:1}" >> firstlines.txt
 			done
 		else
 			for FILE in "${FILES[@]}"

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -98,7 +98,7 @@ task cat_files {
 
 	command <<<
 
-	if [[ ! "~{sep=' ' removal_candidates}" = " " ]]
+	if [[ ! "~{sep=' ' removal_candidates}" = "" ]]
 	then
 		cat ~{sep=" " removal_candidates} >> removal_guide.tsv
 		FILES=(~{sep=" " files})

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -63,7 +63,7 @@ task cat_files {
 		Int preempt = 1
 		Boolean keep_only_unique_lines = false
 		Boolean output_first_lines = true
-		Boolean slice_first_line_first_char = true
+		Boolean strip_first_line_first_char = true
 	}
 	Int disk_size = ceil(size(files, "GB")) * 2
 
@@ -80,21 +80,23 @@ task cat_files {
 		mv temp "~{out_filename}"
 	fi
 
-	if [[ "~{output_first_lines}" = "true"]]
+	if [[ "~{output_first_lines}" = "true" ]]
 	then
 		touch firstlines.txt
-		declare -a FILES
-		readarray -t FILES < <~{sep=" " files}
-		if [[ "~{slice_first_line_first_char}" = "true" ]]
+		FILES=(~{sep=" " files})
+		if [[ "~{strip_first_line_first_char}" = "true" ]]
 		then
+			for FILE in "${FILES[@]}"
+			do
+				firstline=$(head -1 "$FILE")
+				echo "${firstline:1}" >> firstlines.txt
+			done
 		else
 			for FILE in "${FILES[@]}"
 			do
-				head -1 >> firstlines.txt
+				head -1 "$FILE" >> firstlines.txt
 			done
 		fi
-
-		
 	fi
 
 
@@ -110,7 +112,7 @@ task cat_files {
 
 	output {
 		File outfile = "~{out_filename}"
-		File? first_lines
+		File? first_lines = "firstlines.txt"
 	}
 }
 

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -88,8 +88,9 @@ task cat_files {
 		then
 			for FILE in "${FILES[@]}"
 			do
+				echo "${firstline}"
 				firstline=$(head -1 "$FILE")
-				echo "${firstline:1}" >> firstlines.txt
+				echo "${firstline:0}" >> firstlines.txt
 			done
 		else
 			for FILE in "${FILES[@]}"

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -87,7 +87,7 @@ task cat_files {
 	input {
 		Array[File] files
 		Array[File]? removal_candidates
-		Float? removal_threshold
+		Float removal_threshold = 0.05
 		String out_filename = "all.txt"
 		Int preempt = 1
 		Boolean keep_only_unique_lines = false
@@ -98,7 +98,7 @@ task cat_files {
 
 	command <<<
 
-	if [[ ! ~{sep=" " removal_candidates} = " " ]]
+	if [[ ! "~{sep=' ' removal_candidates}" = " " ]]
 	then
 		cat ~{sep=" " removal_candidates} >> removal_guide.tsv
 		FILES=(~{sep=" " files})
@@ -149,10 +149,6 @@ task cat_files {
 		rm "~{out_filename}"
 		mv temp "~{out_filename}"
 	fi
-
-	
-
-
 	>>>
 
 	runtime {


### PR DESCRIPTION
Total rewrite of the cat files task to add these features:
* A metadata file can be included that will reference the files you're trying to cat. If in the metadata file, there is a to-be-cat file that has a float below a value the user specifies, the to-be-cat file will not be cat. This uses bc, hence a new Docker image.
* The first line of every to-be-cat file can be extracted, with or without the first character of that line, and saved to a new file.

These two features mean we can now, respectively:
* Filter out entire samples that have too much bad (eg, too much low coverage) data
* Keep track of which samples have been added, so we can focus on only those when creating Nextstrain subtrees