### PR TITLE
Add a task to combine WDL strings

### DIFF
--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -63,7 +63,7 @@ task cat_strings {
 
 	input {
 		Array[String] strings
-		String outfile = "pull_reports.txt"
+		String out = "pull_reports.txt"
 		Int disk_size = 10
 	}
 
@@ -82,6 +82,10 @@ task cat_strings {
 		docker: "ashedpotatoes/sranwrp:1.1.6"
 		memory: "8 GB"
 		preemptible: 2
+	}
+
+	output {
+		File outfile = out
 	}
 }
 

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -68,13 +68,7 @@ task cat_strings {
 	}
 
 	command <<<
-		echo "~{sep=' ' strings}"
-		python3 << CODE
-		strings_list = ['~{sep="','" strings}']
-		with open("~{out}", "w") as f:
-			for report in strings_list:
-				catfile.write(f"{report}\n")
-		CODE
+		printf "~{sep='\n' strings}"
 	>>>
 
 	runtime {
@@ -83,10 +77,6 @@ task cat_strings {
 		docker: "ashedpotatoes/sranwrp:1.1.6"
 		memory: "8 GB"
 		preemptible: 2
-	}
-
-	output {
-		File outfile = out
 	}
 }
 

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -70,7 +70,7 @@ task cat_strings {
 	command <<<
 		python3 << CODE
 		strings_list = ['~{sep="','" strings}']
-		with open("~{outfile}", "w") as f:
+		with open("~{out}", "w") as f:
 			for report in strings_list:
 				catfile.write(f"{report}\n")
 		CODE

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -68,7 +68,7 @@ task cat_strings {
 	}
 
 	command <<<
-		printf "~{sep='\n' strings}"
+		printf "~{sep='\n' strings}" > "~{out}"
 	>>>
 
 	runtime {
@@ -77,6 +77,10 @@ task cat_strings {
 		docker: "ashedpotatoes/sranwrp:1.1.6"
 		memory: "8 GB"
 		preemptible: 2
+	}
+
+	output {
+		outfile = out
 	}
 }
 

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -58,6 +58,33 @@ task extract_accessions_from_file {
 	}
 }
 
+task cat_strings {
+	# Concatenate Array[String] into a single File.
+
+	input {
+		Array[String] strings
+		String outfile = "pull_reports.txt"
+		Int disk_size = 10
+	}
+
+	command <<<
+		python3 << CODE
+		strings_list = ['~{sep="','" strings}']
+		with open("~{outfile}", "w") as f:
+			for report in strings_list:
+				catfile.write(f"{report}\n")
+		CODE
+	>>>
+
+	runtime {
+		cpu: 4
+		disks: "local-disk " + disk_size + " SSD"
+		docker: "ashedpotatoes/sranwrp:1.1.6"
+		memory: "8 GB"
+		preemptible: 2
+	}
+}
+
 task cat_files {
 	# Concatenate Array[File] into a single File.
 	#

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -68,6 +68,7 @@ task cat_strings {
 	}
 
 	command <<<
+		echo "~{sep=' ' strings}"
 		python3 << CODE
 		strings_list = ['~{sep="','" strings}']
 		with open("~{out}", "w") as f:

--- a/tasks/pull_fastqs.wdl
+++ b/tasks/pull_fastqs.wdl
@@ -282,7 +282,7 @@ task pull_fq_from_biosample {
 	output {
 		Array[File?] fastqs = glob("*.fastq")
 		File? tarball_fastqs = "~{biosample_accession}.tar"
-		File results = "~{biosample_accession}_pull_results.txt"
+		String results = read_string("~{biosample_accession}_pull_results.txt")
 	}
 }
 


### PR DESCRIPTION
And change pull_fq_from_biosample's report from file to string. 

This prevents Cromwell's sluggish file localization from causing us grief when trying to combine a bunch of scattered output.