### PR TITLE
Add tasks for writing CSV/TSV files

### DIFF
--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -363,14 +363,20 @@ task map_to_tsv_or_csv {
 	then
 		sort -o ~{outfile}.tsv ~{outfile}.tsv
 	fi
-	python 3 << CODE
+	python3 << CODE
 	import pandas
-	unordered = pd.read_csv("~{outfile}", sep='\t')
+	unordered = pandas.read_csv("~{outfile}", sep='\t')
 	if "~{transpose}" == "true":
 		transposed = unordered.T
-		if "~{csv}" == "true" then transposed.to_csv("~{outfile}.csv"); else transposed.to_csv("~{outfile}.tsv", sep='\t')
+		if "~{csv}" == "true":
+			transposed.to_csv("~{outfile}.csv")
+		else:
+			transposed.to_csv("~{outfile}.tsv", sep='\t')
 	else:
-		if "~{csv}" == "true" then unordered.to_csv("~{outfile}.csv"); else unordered.to_csv("~{outfile}.tsv", sep='\t')
+		if "~{csv}" == "true":
+			unordered.to_csv("~{outfile}.csv")
+		else:
+			unordered.to_csv("~{outfile}.tsv", sep='\t')
 	CODE
 	
 	>>>
@@ -378,7 +384,7 @@ task map_to_tsv_or_csv {
 	runtime {
 		cpu: 4
 		disks: "local-disk " + 10 + " HDD"
-		docker: "ashedpotatoes/sranwrp:1.1.8"
+		docker: "ashedpotatoes/sranwrp:1.1.15"
 		memory: "8 GB"
 		preemptible: 2
 	}

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -359,6 +359,7 @@ task map_to_tsv_or_csv {
 	
 	command <<<
 	mv ~{write_map(the_map)} map.tsv
+	cat map.tsv
 	if [[ "~{ordered}" == "true" ]]
 	then
 		sort -o map.tsv map.tsv
@@ -366,17 +367,19 @@ task map_to_tsv_or_csv {
 	python3 << CODE
 	import pandas
 	raw = pandas.read_csv("map.tsv", sep='\t')
+	print(raw)
 	if "~{transpose}" == "true":
 		transposed = raw.T
+		print(transposed)
 		if "~{csv}" == "true":
-			transposed.to_csv("~{outfile}.csv")
+			transposed.to_csv("~{outfile}.csv", index=False)
 		else:
-			transposed.to_csv("~{outfile}.tsv", sep='\t')
+			transposed.to_csv("~{outfile}.tsv", sep='\t', index=False)
 	else:
 		if "~{csv}" == "true":
-			raw.to_csv("~{outfile}.csv")
+			raw.to_csv("~{outfile}.csv", index=False)
 		else:
-			raw.to_csv("~{outfile}.tsv", sep='\t')
+			raw.to_csv("~{outfile}.tsv", sep='\t', index=False)
 	CODE
 	
 	>>>
@@ -391,6 +394,7 @@ task map_to_tsv_or_csv {
 
 	output {
 		File tsv_or_csv = glob(outfile+"*")[0]
+		File? debug_map = "map.tsv"
 	}
 }
 

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -370,7 +370,7 @@ task map_to_tsv_or_csv {
 	fi
 	python3 << CODE
 	import pandas
-	raw = pandas.read_csv("map.tsv", sep='\t', index_col=0, names="~{sep='' column_names}")
+	raw = pandas.read_csv("map.tsv", sep='\t', index_col=0, names=["~{sep='' column_names}"])
 	raw.fillna("N/A", inplace=True)  # necessary b/c Pandas thinks "NA" is NaN and then leaves a black space in CSV
 	
 	def round_values(x):

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -348,6 +348,29 @@ task compare_files {
 	}
 }
 
+task map_to_tsv {
+	input {
+		Map[String, String] the_map
+		String outfile = "something.tsv"
+	}
+	
+	command <<<
+	mv ~{write_map(the_map)} ~{outfile}
+	>>>
+	
+	runtime {
+		cpu: 4
+		disks: "local-disk " + 10 + " HDD"
+		docker: "ashedpotatoes/sranwrp:1.1.8"
+		memory: "8 GB"
+		preemptible: 2
+	}
+
+	output {
+		File tsv = outfile
+	}
+}
+
 
 ## This task removes invalid output from pull_from_SRA_accession.
 ## Array[Array[File]?] will return empty subarrays sometimes, such

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -358,25 +358,25 @@ task map_to_tsv_or_csv {
 	}
 	
 	command <<<
-	mv ~{write_map(the_map)} ~{outfile}.tsv
+	mv ~{write_map(the_map)} map.tsv
 	if [[ "~{ordered}" == "true" ]]
 	then
-		sort -o ~{outfile}.tsv ~{outfile}.tsv
+		sort -o map.tsv map.tsv
 	fi
 	python3 << CODE
 	import pandas
-	unordered = pandas.read_csv("~{outfile}", sep='\t')
+	raw = pandas.read_csv("map.tsv", sep='\t')
 	if "~{transpose}" == "true":
-		transposed = unordered.T
+		transposed = raw.T
 		if "~{csv}" == "true":
 			transposed.to_csv("~{outfile}.csv")
 		else:
 			transposed.to_csv("~{outfile}.tsv", sep='\t')
 	else:
 		if "~{csv}" == "true":
-			unordered.to_csv("~{outfile}.csv")
+			raw.to_csv("~{outfile}.csv")
 		else:
-			unordered.to_csv("~{outfile}.tsv", sep='\t')
+			raw.to_csv("~{outfile}.tsv", sep='\t')
 	CODE
 	
 	>>>

--- a/tasks/processing_tasks.wdl
+++ b/tasks/processing_tasks.wdl
@@ -367,7 +367,7 @@ task map_to_tsv_or_csv {
 	python3 << CODE
 	import pandas
 	raw = pandas.read_csv("map.tsv", sep='\t')
-	print(raw)
+	raw.fillna("N/A")  # necessary b/c Pandas thinks "NA" is NaN and then leaves a black space in CSV
 	if "~{transpose}" == "true":
 		transposed = raw.T
 		print(transposed)


### PR DESCRIPTION
Add a simple task for writing a CSV from arrays, and a more advanced task for writing CSVs/TSVs from the [WDL map type](https://github.com/openwdl/wdl/blob/main/versions/1.1/SPEC.md#mapp-y). The complex tasks' defaults reflect the intended use case of making a CSV of QC information for CDPH's LIMS system.

Tested and passes on Terra.